### PR TITLE
noRender mode now runs in one process

### DIFF
--- a/generation/grid_generator.py
+++ b/generation/grid_generator.py
@@ -6,11 +6,7 @@ from simulation import time
 from generation import place_parser
 from plotting import logging
 
-def generate(model_data, needTypes):
-    needTypesDict = {}
-    for needType in needTypes:
-        needTypesDict[needType.getName()] = needType
-
+def generate(model_data):
     size = int(model_data["gridSize"])
     places_file = model_data["places"]
 

--- a/generation/person_generator.py
+++ b/generation/person_generator.py
@@ -2,7 +2,7 @@ import random
 from model import person, grid, place_characteristics, disease
 from generation import script_loader, disease_parser
 
-def generate(grid, model_data, needTypes, diseaseTypes):
+def generate(model_data, needTypes, diseaseTypes):
     persons = []
     behaviours = script_loader.readObjectsFromScript(model_data["person_behaviours"], "person_behaviours")
     behaviourFreqs = [b.getFrequency() for b in behaviours]
@@ -15,7 +15,7 @@ def generate(grid, model_data, needTypes, diseaseTypes):
     for i in range(numPersons):
         behaviour = random.choices(behaviours, behaviourFreqs)[0]
         thePerson = person.Person(str(i),
-                random.randrange(0, 100), grid.get(0,0), needTypes,
+                random.randrange(0, 100), None, needTypes,
                 diseaseTypes, behaviour, random.random())
         persons.append(thePerson)
     persons[0].name = "Bobby"

--- a/main.py
+++ b/main.py
@@ -7,17 +7,13 @@ from multiprocessing import Process, Manager, Value
 import importlib.util
 import inspect
 
-import generation.grid_generator, generation.person_generator, generation.script_loader
-from rendering.renderer import Renderer
+from generation import grid_generator, person_generator, script_loader
 from simulation.simulation import Simulation
 from simulation import time
-from profiler.profiler import profilerObj
 from plotting import logging
 
 MINUTES_PER_REAL_SECOND = 1000
 MAX_RENDER_PER_SEC = 5
-
-killSimulationLoop = False
 
 def readArguments():
     #Setup argparse
@@ -28,6 +24,7 @@ def readArguments():
     argparser.add_argument("--num-days", dest="numDays", type=int, default=0)
     return argparser.parse_args()
 
+#TODO: Move somewhere else?
 def getCurrentTimeMillis():
     return round(pytime.time() * 1000)
 
@@ -39,29 +36,29 @@ def registerLoggingCategories():
     logging.registerCategory("bobby_needs")
     logging.registerCategory("infections")
 
-def main():
-    args = readArguments()
-    registerLoggingCategories()
+def mainRender(args):
+    #Import this module only in render mode, as it needs pygame and PyOpenGL
+    from rendering.renderer import Renderer
 
     lastUpdate = getCurrentTimeMillis()
     running = True
     loops = 0
 
-    logging.write("output", "starting main loop")
     ########
     queue = Manager().Queue()
     killSim = Value('i', 0)
     simProcess = Process(target=simLoop, args=(queue, killSim,))
     simProcess.start()
 
+    #Initialize the renderer
     initialData = queue.get(block=True)
-    if not args.noRender:
-        numPersons = initialData[0]
-        gridSize = initialData[1]
-        gridData = initialData[2]
-        theRenderer = Renderer(numPersons)
-        theRenderer.initPlaceBuffer(gridSize, gridData)
+    numPersons = initialData[0]
+    gridSize = initialData[1]
+    gridData = initialData[2]
+    theRenderer = Renderer(numPersons)
+    theRenderer.initPlaceBuffer(gridSize, gridData)
 
+    #Get the first simulation datum
     simData = queue.get(block=True)
     simPersons = simData[1]
     simNow = simData[0]
@@ -72,16 +69,12 @@ def main():
         now = getCurrentTimeMillis()
         deltaTime = now - lastUpdate
 
-        if not args.noRender:
-            running = theRenderer.fetchEvents(deltaTime)
-            if not queue.empty():
-                simData = queue.get(block=False)
-                simPersons = simData[1]
-                simNow = simData[0]
-            theRenderer.render(simPersons, deltaTime, simNow)
-        else:
-            simData = queue.get(block=True)
+        running = theRenderer.fetchEvents(deltaTime)
+        if not queue.empty():
+            simData = queue.get(block=False)
+            simPersons = simData[1]
             simNow = simData[0]
+        theRenderer.render(simPersons, deltaTime, simNow)
         nowOb = time.Timestamp(simNow)
         
         loops += 1
@@ -91,9 +84,7 @@ def main():
         if args.numDays > 0 and nowOb.day() >= args.numDays:
             running = False
 
-    logging.write("output", "shutting down")
-    if not args.noRender:
-        theRenderer.quit()
+    theRenderer.quit()
     killSim.value = 1
     while(not queue.empty()):
         queue.get(block=False)
@@ -101,19 +92,41 @@ def main():
     
 def simLoop(connection, killMe):
     #SETUP
-    args = readArguments()
-
     registerLoggingCategories()
+    args = readArguments()
+    modelData = loadModelData(args)
+    theSimulation = setupSimulation(modelData)
 
-    model_data_parser = configparser.ConfigParser()
-    model_data_parser.read(args.modelsConfigFile)
-    model_data = model_data_parser[args.model]
+    #We need to send the grid data to the renderer.
+    connection.put([len(theSimulation.persons), theSimulation.grid.size, [p.char.placeType.value for p in theSimulation.grid.internal_grid]])
 
-    logging.write("output", "generating")
-    needTypes = generation.script_loader.readObjectsFromScript(model_data["need_types"], "need_types")
-    diseaseTypes  = generation.script_loader.readObjectsFromScript(model_data["disease_types"], "disease_types")
-    theGrid = generation.grid_generator.generate(model_data, needTypes)
-    persons = generation.person_generator.generate(theGrid, model_data, needTypes, diseaseTypes)
+    #MAIN LOOP
+    lastUpdate = getCurrentTimeMillis()
+    last100 = getCurrentTimeMillis()
+    i = 0
+    while killMe.value == 0:
+        now = getCurrentTimeMillis()
+        deltaTime = now - lastUpdate
+        theSimulation.simulate()
+        if deltaTime > 1000/MAX_RENDER_PER_SEC and connection.empty():
+            personData = list(map(lambda p: ((p.currentPosition.x, p.currentPosition.y), p.direction, p.travelStart.now(), p.travelEnd.now()) if p.isTravelling() else ((p.currentPosition.x, p.currentPosition.y), (0,0), 0, 0), theSimulation.persons))
+            connection.put([theSimulation.now.now(), personData])
+            lastUpdate = now
+        i += 1
+        if i % 100 == 0:
+            print("100 simulation steps took " + str(getCurrentTimeMillis() - last100) + "ms")
+            last100 = getCurrentTimeMillis()
+
+def loadModelData(args):
+    modelDataParser = configparser.ConfigParser()
+    modelDataParser.read(args.modelsConfigFile)
+    return modelDataParser[args.model]
+
+def setupSimulation(model_data):
+    needTypes = script_loader.readObjectsFromScript(model_data["need_types"], "need_types")
+    diseaseTypes  = script_loader.readObjectsFromScript(model_data["disease_types"], "disease_types")
+    theGrid = grid_generator.generate(model_data)
+    persons = person_generator.generate(model_data, needTypes, diseaseTypes)
 
     for needType in needTypes:
         needType.initialize(needTypes, persons, theGrid)
@@ -123,27 +136,30 @@ def simLoop(connection, killMe):
         diseaseType.initialize(needTypes)
         logging.registerCategory("disease." + diseaseType.getName())
 
-    #We need to send the grid data to the renderer.
-    connection.put([len(persons), theGrid.size, [p.char.placeType.value for p in theGrid.internal_grid]])
+    return Simulation(persons, theGrid, diseaseTypes)
 
-    theSimulation = Simulation(persons, diseaseTypes)
+def mainNoRender(args):
+    #Startup code
+    registerLoggingCategories()
+    modelData = loadModelData(args)
+    theSimulation = setupSimulation(modelData)
 
-    #MAIN LOOP
-    lastUpdate = getCurrentTimeMillis()
+    #main loop
+    running = True
     last100 = getCurrentTimeMillis()
-    i = 1
-    while killMe.value == 0:
-        now = getCurrentTimeMillis()
-        deltaTime = now - lastUpdate
+    i = 0
+    while running:
         theSimulation.simulate()
-        if deltaTime > 1000/MAX_RENDER_PER_SEC and connection.empty():
-            personData = list(map(lambda p: ((p.currentPosition.x, p.currentPosition.y), p.direction, p.travelStart.now(), p.travelEnd.now()) if p.isTravelling() else ((p.currentPosition.x, p.currentPosition.y), (0,0), 0, 0), theSimulation.persons))
-            connection.put([theSimulation.now.now(), personData])
-            lastUpdate = now
+        i += 1
         if i % 100 == 0:
             print("100 simulation steps took " + str(getCurrentTimeMillis() - last100) + "ms")
             last100 = getCurrentTimeMillis()
-        i += 1
+        if args.numDays > 0 and theSimulation.now.day() >= args.numDays:
+            running = False
 
 if __name__ == "__main__":
-    main()
+    args = readArguments()
+    if args.noRender:
+        mainNoRender(args)
+    else:
+        mainRender(args)

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -10,10 +10,11 @@ from profiler.profiler import profilerObj
 SIMULATION_TICK_LENGTH = 5 * time.MINUTE
 
 class Simulation:
-    def __init__(self, persons, diseaseTypes):
+    def __init__(self, persons, grid, diseaseTypes):
         self.now = time.Timestamp(time.HOUR * 0)
         self.persons = persons
         self.bobby = persons[0]
+        self.grid = grid
         self.lastUpdate = -1
 
         self.diseaseTypes = diseaseTypes


### PR DESCRIPTION
If noRender mode is activated, it runs in one process and does not import pygame/PyOpenGL/the renderer module.
If noRender is not activated, it works as before.

As a neat side effect, this should speed up the noRender mode as no inter-process communication is required to happen.

fixes #33 